### PR TITLE
Adding nowww.conf to 301 redirect a www subdomain to the main domain

### DIFF
--- a/src/nginx-bp/redirects/nowww.conf
+++ b/src/nginx-bp/redirects/nowww.conf
@@ -1,0 +1,5 @@
+server
+{
+    server_name ~^(?=www\.);
+    return 301 $scheme://$host$request_uri;
+}


### PR DESCRIPTION
Just adding the nowww.conf file to 301 redirect a www subdomain to the main domain.

This closes issue #2
