### PR TITLE
Don't create cache when PHPSESSID cookie exists

### DIFF
--- a/src/nginx-bp/enable/cache.conf
+++ b/src/nginx-bp/enable/cache.conf
@@ -7,6 +7,7 @@ fastcgi_cache_methods           GET HEAD;
 
 fastcgi_hide_header             "Set-Cookie";
 fastcgi_cache_bypass            $cookie_PHPSESSID;
+fastcgi_no_cache                $cookie_PHPSESSID;
 
 fastcgi_cache_use_stale         error timeout invalid_header http_500;
 fastcgi_cache_valid             200 301 302 304 1h;


### PR DESCRIPTION
Need this as while clients with the PHPSESSID cookie are never served a
cache, they still create new caches meaning that clients that does not
have PHPSESSID cookie set may be served a cached page from a logged in
user, spelling all kinds of trouble (ie. users appearing logged in as an
administrator).
