### PR TITLE
add named location for php

### DIFF
--- a/src/nginx-bp/locations/php.conf
+++ b/src/nginx-bp/locations/php.conf
@@ -2,3 +2,8 @@ location ~ ^.+\.php(?:/.*)?$
 {
     include                     nginx-bp/enable/php.conf;
 }
+
+location @php
+{
+    include                     nginx-bp/enable/php.conf;
+}


### PR DESCRIPTION
Допустим, на моем сайте используются ЧПУ и GET параметры, а именно http://site.local/search/?q=test. 
Тогда, для передачи GET параметров в скрипт, который обрабатывает ЧПУ, необходимо прописать следующее:

``` conf
location /
{
    try_files   $uri $uri/ /index.php?$args;
}
```

В данном случае, URI (внутреннее представление nginx) изменяется (перезаписывается на index.php) и необходимо явно передавать GET параметры в скрипт.

Или использовать именованный локейшен:

``` conf
location /
{
    try_files   $uri $uri/ @php;
}
```

В данном случае, URI не изменяется и все работает штатно.

Инованные локешены не могут быть доступны извне, так что нам надо оставить существующий локейшен для обработки запросов прямо на php-файлы.
